### PR TITLE
Fix GridView when called with Region.Scrolling

### DIFF
--- a/src/System.CommandLine.Rendering/Views/GridView.cs
+++ b/src/System.CommandLine.Rendering/Views/GridView.cs
@@ -96,9 +96,10 @@ namespace System.CommandLine.Rendering.Views
             Size[,] sizes = GetGridSizes(renderer, new Size(region.Width, region.Height));
 
             int top = region.Top;
+            int regionLeft = region.Left;
             for (int row = 0; row < _rows.Count; row++)
             {
-                int left = region.Left;
+                int left = regionLeft;
                 int maxRowHeight = 0;
                 for (int column = 0; column < _columns.Count; column++)
                 {


### PR DESCRIPTION
Hi,

when rendering `GridView` with `Region.Scrolling` the grid isn't displayed correctly because `region.Left` returns the current console `Left` coordinate.

We need to store the initial left value of the region passed in.